### PR TITLE
Refactor/comment refactoring

### DIFF
--- a/src/main/kotlin/wafflestudio/team4/reddit/domain/comment/api/CommentController.kt
+++ b/src/main/kotlin/wafflestudio/team4/reddit/domain/comment/api/CommentController.kt
@@ -39,7 +39,8 @@ class CommentController(
         @PathVariable("post_id") postId: Long,
         @Valid @RequestBody createRequest: CommentDto.CreateRequest,
     ): ResponseEntity<CommentDto.Response> {
-        val newComment = commentService.createComment(user, postId, createRequest)
+        val mergedUser = commentService.mergeUser(user)
+        val newComment = commentService.createComment(mergedUser, postId, createRequest)
         return ResponseEntity.status(201).body(CommentDto.Response(newComment))
     }
 
@@ -50,7 +51,8 @@ class CommentController(
         @PathVariable("comment_id") commentId: Long,
         @Valid @RequestBody replyRequest: CommentDto.ReplyRequest,
     ): ResponseEntity<CommentDto.Response> {
-        val newReplyComment = commentService.replyComment(user, postId, commentId, replyRequest)
+        val mergedUser = commentService.mergeUser(user)
+        val newReplyComment = commentService.replyComment(mergedUser, postId, commentId, replyRequest)
         return ResponseEntity.status(201).body(CommentDto.Response(newReplyComment))
     }
 
@@ -59,7 +61,8 @@ class CommentController(
         @CurrentUser user: User,
         @PathVariable("comment_id") commentId: Long,
     ): ResponseEntity<String> {
-        commentService.deleteComment(user, commentId)
+        val mergedUser = commentService.mergeUser(user)
+        commentService.deleteComment(mergedUser, commentId)
         return ResponseEntity.noContent().build()
     }
 
@@ -69,7 +72,8 @@ class CommentController(
         @PathVariable("comment_id") commentId: Long,
         @Valid @RequestBody modifyRequest: CommentDto.ModifyRequest
     ): CommentDto.Response {
-        val modifiedComment = commentService.modifyComment(user, commentId, modifyRequest)
+        val mergedUser = commentService.mergeUser(user)
+        val modifiedComment = commentService.modifyComment(mergedUser, commentId, modifyRequest)
         return CommentDto.Response(modifiedComment)
     }
 
@@ -79,6 +83,7 @@ class CommentController(
         @PathVariable("comment_id") commentId: Long,
         @RequestParam(name = "isUp", required = true) isUp: Int,
     ): CommentDto.Response {
-        return CommentDto.Response(commentService.voteComment(user, commentId, isUp))
+        val mergedUser = commentService.mergeUser(user)
+        return CommentDto.Response(commentService.voteComment(mergedUser, commentId, isUp))
     }
 }

--- a/src/main/kotlin/wafflestudio/team4/reddit/domain/comment/api/CommentController.kt
+++ b/src/main/kotlin/wafflestudio/team4/reddit/domain/comment/api/CommentController.kt
@@ -43,6 +43,17 @@ class CommentController(
         return ResponseEntity.status(201).body(CommentDto.Response(newComment))
     }
 
+    @PostMapping("/{post_id}/{comment_id}/reply/")
+    fun replyComment(
+        @CurrentUser user: User,
+        @PathVariable("post_id") postId: Long,
+        @PathVariable("comment_id") commentId: Long,
+        @Valid @RequestBody replyRequest: CommentDto.ReplyRequest,
+    ): ResponseEntity<CommentDto.Response> {
+        val newReplyComment = commentService.replyComment(user, postId, commentId, replyRequest)
+        return ResponseEntity.status(201).body(CommentDto.Response(newReplyComment))
+    }
+
     @DeleteMapping("/{comment_id}/")
     fun deleteComment(
         @CurrentUser user: User,

--- a/src/main/kotlin/wafflestudio/team4/reddit/domain/comment/dto/CommentDto.kt
+++ b/src/main/kotlin/wafflestudio/team4/reddit/domain/comment/dto/CommentDto.kt
@@ -19,7 +19,9 @@ class CommentDto {
         val parentCommentId: Long?,
         @JsonProperty("children_comment_id")
         val childrenCommentId: List<Long>,
+        @JsonProperty("num_up_votes")
         val numUpVotes: Int,
+        @JsonProperty("num_down_votes")
         val numDownVotes: Int,
         val deleted: Boolean,
         @JsonProperty("created_at")

--- a/src/main/kotlin/wafflestudio/team4/reddit/domain/comment/dto/CommentDto.kt
+++ b/src/main/kotlin/wafflestudio/team4/reddit/domain/comment/dto/CommentDto.kt
@@ -17,8 +17,8 @@ class CommentDto {
         val rootCommentId: Long,
         @JsonProperty("parent_comment_id")
         val parentCommentId: Long?,
-        @JsonProperty("children_comment_id")
-        val childrenCommentId: List<Long>,
+        @JsonProperty("children_comment_id_list")
+        val childrenCommentIdList: List<Long>,
         @JsonProperty("num_up_votes")
         val numUpVotes: Int,
         @JsonProperty("num_down_votes")
@@ -34,7 +34,7 @@ class CommentDto {
             depth = comment.depth,
             rootCommentId = comment.rootComment!!.id,
             parentCommentId = comment.parentComment?.id,
-            childrenCommentId = comment.childrenComments.map { it.id },
+            childrenCommentIdList = comment.childrenComments.map { it.id },
             numUpVotes = comment.votes.count { it.isUp == 2 },
             numDownVotes = comment.votes.count { it.isUp == 0 },
             deleted = comment.deleted == 1 || comment.deleted == 2,

--- a/src/main/kotlin/wafflestudio/team4/reddit/domain/comment/dto/CommentDto.kt
+++ b/src/main/kotlin/wafflestudio/team4/reddit/domain/comment/dto/CommentDto.kt
@@ -1,6 +1,8 @@
 package wafflestudio.team4.reddit.domain.comment.dto
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import wafflestudio.team4.reddit.domain.comment.model.Comment
+import wafflestudio.team4.reddit.domain.user.dto.UserDto
 import java.time.LocalDateTime
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotNull
@@ -8,27 +10,29 @@ import javax.validation.constraints.NotNull
 class CommentDto {
     data class Response(
         val id: Long,
-        val userId: Long,
-        val userName: String,
-        val userImageUrl: String?,
+        val author: UserDto.Response,
         val text: String,
         val depth: Int,
-        val parentId: Long?,
-        val groupId: Long?,
+        @JsonProperty("root_comment_id")
+        val rootCommentId: Long,
+        @JsonProperty("parent_comment_id")
+        val parentCommentId: Long?,
+        @JsonProperty("children_comment_id")
+        val childrenCommentId: List<Long>,
         val numUpVotes: Int,
         val numDownVotes: Int,
         val deleted: Boolean,
+        @JsonProperty("created_at")
         val createdAt: LocalDateTime?
     ) {
         constructor(comment: Comment) : this(
             id = comment.id,
-            userId = comment.user.id,
-            userName = comment.user.username,
-            userImageUrl = comment.user.userProfile?.userImage?.url,
+            author = UserDto.Response(comment.user),
             text = comment.text,
             depth = comment.depth,
-            parentId = comment.parent?.id,
-            groupId = comment.group?.id,
+            rootCommentId = comment.rootComment!!.id,
+            parentCommentId = comment.parentComment?.id,
+            childrenCommentId = comment.childrenComments.map { it.id },
             numUpVotes = comment.votes.count { it.isUp == 2 },
             numDownVotes = comment.votes.count { it.isUp == 0 },
             deleted = comment.deleted == 1 || comment.deleted == 2,
@@ -37,18 +41,16 @@ class CommentDto {
     }
 
     data class CreateRequest(
+        @field:NotBlank
+        val text: String,
+    )
 
+    data class ReplyRequest(
         @field:NotBlank
         val text: String,
 
         @field:NotNull
-        val depth: Int,
-
-        @field:NotNull
-        val parentId: Long = 0L,
-
-        @field:NotNull
-        val groupId: Long = 0L,
+        val parentId: Long,
     )
 
     data class ModifyRequest(

--- a/src/main/kotlin/wafflestudio/team4/reddit/domain/comment/model/Comment.kt
+++ b/src/main/kotlin/wafflestudio/team4/reddit/domain/comment/model/Comment.kt
@@ -7,7 +7,7 @@ import javax.persistence.Entity
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
 import javax.persistence.Table
-import javax.persistence.OneToOne
+import javax.persistence.CascadeType
 import javax.persistence.OneToMany
 import javax.validation.constraints.NotNull
 
@@ -31,13 +31,16 @@ class Comment(
     @field:NotNull
     val depth: Int,
 
-    @OneToOne
-    @JoinColumn(name = "parent_comment_id")
-    var parent: Comment? = null,
-
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "group_comment_id")
-    var group: Comment? = null,
+    var rootComment: Comment? = null,
+
+    @ManyToOne
+    @JoinColumn(name = "parent_comment_id")
+    var parentComment: Comment? = null,
+
+    @OneToMany(mappedBy = "parentComment", cascade = [CascadeType.PERSIST])
+    var childrenComments: MutableList<Comment> = mutableListOf(),
 
     @OneToMany(mappedBy = "comment")
     var votes: MutableList<CommentVote> = mutableListOf(),

--- a/src/main/kotlin/wafflestudio/team4/reddit/domain/comment/repository/CommentRepository.kt
+++ b/src/main/kotlin/wafflestudio/team4/reddit/domain/comment/repository/CommentRepository.kt
@@ -14,13 +14,6 @@ interface CommentRepository : JpaRepository<Comment, Long?> {
         depth: Int = 0,
         pageable: Pageable
     ): Page<Comment>
-    fun findByIdIsAndDeletedIs(id: Long, deleteStatusFilter: Int = 0): Comment?
-    // child 여부 찾기
-    fun findByParentIsAndDeletedIsNot(comment: Comment, deleteStatusFilter: Int = 2): List<Comment>
-    fun existsByParentIsAndDeletedIsNot(comment: Comment, deleteStatusFilter: Int = 2): Boolean
-    fun findByPostIsAndGroupIsAndDeletedIsNotOrderByDepthAsc(
-        post: Post,
-        group: Comment,
-        deleteStatusFilter: Int = 2
-    ): MutableList<Comment>
+    fun findByParentCommentIsAndDeletedIsNot(comment: Comment, deleteStatusFilter: Int = 2): List<Comment>
+    fun existsByParentCommentIsAndDeletedIsNot(comment: Comment, deleteStatusFilter: Int = 2): Boolean
 }

--- a/src/main/kotlin/wafflestudio/team4/reddit/domain/comment/service/CommentService.kt
+++ b/src/main/kotlin/wafflestudio/team4/reddit/domain/comment/service/CommentService.kt
@@ -31,50 +31,37 @@ class CommentService(
             pageRequest
         ).content
 
-        var commentList = mutableListOf<Comment>()
-
-        parentCommentList.forEach {
-            var commentThread = commentRepository.findByPostIsAndGroupIsAndDeletedIsNotOrderByDepthAsc(
-                post,
-                it,
-                2
-            )
-            commentList.addAll(commentThread)
-        }
-        return commentList
+        return parentCommentList
     }
 
     fun createComment(user: User, postId: Long, request: CommentDto.CreateRequest): Comment {
         val post = postRepository.findByIdOrNull(postId) ?: throw PostNotFoundException()
-        var parentComment: Comment? = null
-        var groupComment: Comment? = null
+        val newComment = Comment(
+            user = user,
+            post = post,
+            text = request.text,
+            depth = 1
+        )
+        newComment.rootComment = newComment
+        return commentRepository.save(newComment)
+    }
 
-        // 대댓글 시 부모와 그룹 코멘트 엔티티 찾기
-        if (request.depth != 0) {
-            parentComment = commentRepository.findByIdIsAndDeletedIs(request.parentId, 0)
-                ?: throw CommentNotFoundException() // TODO 혼동 방지를 위해 exception 이름 변경
-            groupComment = commentRepository.findByIdIsAndDeletedIs(request.groupId, 0)
-                ?: throw CommentNotFoundException()
-        }
+    fun replyComment(user: User, postId: Long, parentCommentId: Long, request: CommentDto.ReplyRequest): Comment {
+        val post = postRepository.findByIdOrNull(postId) ?: throw PostNotFoundException()
+        val parentComment = commentRepository.findByIdOrNull(parentCommentId) ?: throw CommentNotFoundException()
 
         val newComment = Comment(
             user = user,
             post = post,
             text = request.text,
-            depth = request.depth,
-            parent = parentComment,
-            group = groupComment
+            depth = parentComment.depth + 1,
+            rootComment = parentComment.rootComment,
+            parentComment = parentComment
         )
-        commentRepository.save(newComment)
+        parentComment.childrenComments.add(newComment)
+        commentRepository.save(parentComment)
 
-        // 그냥 댓글 작성 시 스스로를 부모와 그룹 코멘트로 할당
-        if (request.depth == 0) {
-            newComment.parent = newComment
-            newComment.group = newComment
-        } else
-            return newComment
-
-        return commentRepository.save(newComment)
+        return newComment
     }
 
     fun deleteComment(user: User, commentId: Long): Comment {
@@ -86,11 +73,11 @@ class CommentService(
 
         // 코멘트 children 유무
         fun checkChildAndDelete(comment: Comment): Comment {
-            if (commentRepository.existsByParentIsAndDeletedIsNot(comment, 2) &&
-                commentRepository.findByParentIsAndDeletedIsNot(comment, 2).count() > 1
+            if (commentRepository.existsByParentCommentIsAndDeletedIsNot(comment, 2) &&
+                commentRepository.findByParentCommentIsAndDeletedIsNot(comment, 2).count() > 1
             ) {
                 comment.deleted = 1 // 삭제 보류
-                comment.text = "[deleted]" // reddit에서 이렇게 씀
+                comment.text = "[deleted]" // reddit 스타일
             } else
                 comment.deleted = 2
             return comment
@@ -98,8 +85,8 @@ class CommentService(
         commentRepository.save(checkChildAndDelete(comment))
 
         // parent가 삭제 보류 상태일시 확인하고 업데이트
-        if (comment.parent!!.deleted == 1) {
-            commentRepository.save(checkChildAndDelete(comment.parent!!))
+        if (comment.parentComment!!.deleted == 1) {
+            commentRepository.save(checkChildAndDelete(comment.parentComment!!))
         }
 
         return comment

--- a/src/main/kotlin/wafflestudio/team4/reddit/domain/comment/service/CommentService.kt
+++ b/src/main/kotlin/wafflestudio/team4/reddit/domain/comment/service/CommentService.kt
@@ -12,14 +12,22 @@ import wafflestudio.team4.reddit.domain.comment.repository.CommentRepository
 import wafflestudio.team4.reddit.domain.comment.repository.CommentVoteRepository
 import wafflestudio.team4.reddit.domain.post.exception.PostNotFoundException
 import wafflestudio.team4.reddit.domain.post.repository.PostRepository
+import wafflestudio.team4.reddit.domain.user.exception.UserNotFoundException
 import wafflestudio.team4.reddit.domain.user.model.User
+import wafflestudio.team4.reddit.domain.user.repository.UserRepository
 
 @Service
 class CommentService(
     private val commentRepository: CommentRepository,
     private val commentVoteRepository: CommentVoteRepository,
     private val postRepository: PostRepository,
+    private val userRepository: UserRepository,
 ) {
+
+    fun mergeUser(user: User): User {
+        return userRepository.findByIdOrNull(user.id) ?: throw UserNotFoundException()
+    }
+
     fun getComments(lastCommentId: Long, size: Int, postId: Long): List<Comment> {
         val post = postRepository.findByIdOrNull(postId) ?: throw PostNotFoundException()
         val pageRequest: PageRequest = PageRequest.of(0, size)


### PR DESCRIPTION
Comment 모델: 
- 기존 parent만 있던 것에서 children도 추가하였습니다.
- 기존 property 이름들을 좀 더 명확하게 바꿨습니다.

Comment DTO: 
- 기존 property 이름들을 좀 더 명확하게 바꿨습니다.
- children들의 id를 담은 children_comment_id_list를 추가하였습니다.
- JsonProperty로 property명들을 snake_case로 변경하였습니다.

CommentService/Controller:
- 코멘트 작성시 CreateComment 하나로만 처리하던 것을 댓글 작성(createComment)과 대댓글 작성(replyComment)으로 두 개로 나눴습니다.
- 새 api: /postid/commentid/reply (곧 노션에 등록하겠습니다)